### PR TITLE
Add OSGi R7 JAX-RS Whiteboard App and Endpoints

### DIFF
--- a/config/bnd.bnd
+++ b/config/bnd.bnd
@@ -1,0 +1,1 @@
+Export-Package: org.millipede.http.config

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>millipede-social-aggregator-parent</artifactId>
+        <groupId>org.millipede</groupId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>http-config</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.cmpn</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>
+

--- a/config/src/main/java/org/millipede/http/config/package-info.java
+++ b/config/src/main/java/org/millipede/http/config/package-info.java
@@ -1,0 +1,5 @@
+@RequireConfigurator
+package org.millipede.http.config;
+
+import org.osgi.service.configurator.annotations.RequireConfigurator;
+

--- a/config/src/main/resources/OSGI-INF/configurator/configuration.json
+++ b/config/src/main/resources/OSGI-INF/configurator/configuration.json
@@ -1,0 +1,8 @@
+{
+  ":configurator:resource-version": 1,
+  ":configurator:symbolic-name": "http-config",
+  ":configurator:version": "1.0.0",
+  "org.apache.felix.http~": {
+    "org.osgi.service.http.port": "$[env:SOCIAL_AGGREGATOR_SERVER_HTTP_PORT;default=8090]"
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: social-aggregator
     networks:
       - social-aggregator-network
-    command: ["./wait-for-it.sh", "http://db:7474", "--", "karaf", "run"]
+    command: ["karaf", "run"]
 
 networks:
   social-aggregator-network:

--- a/endpoint/pom.xml
+++ b/endpoint/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.millipede</groupId>
+        <artifactId>millipede-social-aggregator-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>endpoint</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.cmpn</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.annotation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.jax.rs</groupId>
+            <artifactId>org.apache.aries.jax.rs.whiteboard</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.jax.rs</groupId>
+            <artifactId>org.apache.aries.jax.rs.jackson</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/endpoint/src/main/java/resource/HelloWorld.java
+++ b/endpoint/src/main/java/resource/HelloWorld.java
@@ -1,0 +1,43 @@
+package resource;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsResource;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import java.util.HashMap;
+import java.util.Map;
+
+
+//http://localhost:8080/employee
+
+//http://localhost:8181/employee
+
+/***
+ * Declaration options:
+ * - Without annotation JaxrsResource from whiteboard
+ * @Component(service = EmployeeResource.class, property = {"osgi.jaxrs.resource=true"})
+ * - With annotation JaxrsResource from whiteboard
+ * @JaxrsResource
+ * @Component(service = EmployeeResource.class)
+ */
+
+@JaxrsResource
+@Component(service = HelloWorld.class)
+@Path("/hello")
+public class HelloWorld {
+
+  @GET
+  @Produces(APPLICATION_JSON)
+  public Map<String, String> getValue() {
+    HashMap<String, String> map = new HashMap<>();
+    map.put("root", "rootValue");
+    return map;
+  }
+
+}
+
+

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.millipede</groupId>
+        <artifactId>millipede-social-aggregator-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>http</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.cmpn</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.annotation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.jax.rs</groupId>
+            <artifactId>org.apache.aries.jax.rs.whiteboard</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.jax.rs</groupId>
+            <artifactId>org.apache.aries.jax.rs.jackson</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/http/src/main/java/http/MyApplication.java
+++ b/http/src/main/java/http/MyApplication.java
@@ -1,0 +1,13 @@
+package http;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsApplicationBase;
+import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsName;
+
+import javax.ws.rs.core.Application;
+
+@Component(service = Application.class)
+@JaxrsApplicationBase("my-app")
+@JaxrsName("MyApplication")
+public class MyApplication extends Application {
+}

--- a/osgi/karaf/feature/pom.xml
+++ b/osgi/karaf/feature/pom.xml
@@ -26,7 +26,62 @@
 
         <!-- Override version for maven-deploy-plugin due to a bug similar to the maven-install-plugin -->
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+
+        <org.apache.aries.jax.rs.whiteboard.version>1.0.9-SNAPSHOT</org.apache.aries.jax.rs.whiteboard.version>
+        <org.apache.aries.jax.rs.jackson.version>1.0.3-SNAPSHOT</org.apache.aries.jax.rs.jackson.version>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.millipede</groupId>
+            <artifactId>osgi-config-extension-feature</artifactId>
+            <version>1.0.0</version>
+            <type>xml</type>
+            <classifier>features</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.jax.rs</groupId>
+            <artifactId>org.apache.aries.jax.rs.features.whiteboard</artifactId>
+            <version>${org.apache.aries.jax.rs.whiteboard.version}</version>
+            <type>xml</type>
+            <classifier>features</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.jax.rs</groupId>
+            <artifactId>org.apache.aries.jax.rs.features.jackson</artifactId>
+            <version>${org.apache.aries.jax.rs.jackson.version}</version>
+            <type>xml</type>
+            <classifier>features</classifier>
+        </dependency>
+
+        <!-- Application configuration - OSGi R7 Configurator -->
+        <dependency>
+            <groupId>org.millipede</groupId>
+            <artifactId>http-config</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.millipede</groupId>
+            <artifactId>http</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.millipede</groupId>
+            <artifactId>endpoint</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- Additional dependencies to get the server starting -->
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.http.jetty</artifactId>
+            <version>4.0.18</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.spifly</groupId>
+            <artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
+            <version>1.2.3</version>
+        </dependency>
+    </dependencies>
 
     <build>
         <pluginManagement>
@@ -47,7 +102,7 @@
                 <artifactId>karaf-maven-plugin</artifactId>
                 <configuration>
                     <startLevel>80</startLevel>
-                    <aggregateFeatures>false</aggregateFeatures>
+                    <aggregateFeatures>true</aggregateFeatures>
                     <enableGeneration>true</enableGeneration>
                     <includeProjectArtifact>false</includeProjectArtifact>
                 </configuration>
@@ -74,6 +129,60 @@
                     <version>1.0.0</version>
                     <type>xml</type>
                     <classifier>features</classifier>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>java11</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <properties>
+                <jakarta.xml.bind-api.version>2.3.3</jakarta.xml.bind-api.version>
+                <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
+                <jakarta.activation-api.version>1.2.2</jakarta.activation-api.version>
+                <jakarta.xml.ws-api.version>2.3.3</jakarta.xml.ws-api.version>
+            </properties>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>${jakarta.xml.bind-api.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>jakarta.annotation</groupId>
+                        <artifactId>jakarta.annotation-api</artifactId>
+                        <version>${jakarta.annotation-api.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>jakarta.activation</groupId>
+                        <artifactId>jakarta.activation-api</artifactId>
+                        <version>${jakarta.activation-api.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>jakarta.xml.ws</groupId>
+                        <artifactId>jakarta.xml.ws-api</artifactId>
+                        <version>${jakarta.xml.ws-api.version}</version>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+            <dependencies>
+                <dependency>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>jakarta.annotation</groupId>
+                    <artifactId>jakarta.annotation-api</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>jakarta.activation</groupId>
+                    <artifactId>jakarta.activation-api</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>jakarta.xml.ws</groupId>
+                    <artifactId>jakarta.xml.ws-api</artifactId>
                 </dependency>
             </dependencies>
         </profile>

--- a/osgi/runtime/app-equinox.bndrun
+++ b/osgi/runtime/app-equinox.bndrun
@@ -25,5 +25,51 @@ feature.gogo: \
     bnd.identity;id='org.apache.felix.gogo.jline',\
 	bnd.identity;id='org.apache.felix.gogo.runtime'
 
+feature.config-admin: \
+    bnd.identity;id='org.apache.felix.configadmin.plugin.interpolation',\
+    bnd.identity;id='org.glassfish.jakarta.json'
+
 -runrequires: \
-    ${feature.gogo}
+    ${feature.config-admin},\
+    bnd.identity;id='http-config',\
+    ${feature.gogo}, \
+    bnd.identity;id='http', \
+    bnd.identity;id='endpoint', \
+    bnd.identity;id='org.apache.aries.jax.rs.jackson'
+-runbundles: \
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
+	com.fasterxml.jackson.core.jackson-annotations;version='[2.9.0,2.9.1)',\
+	com.fasterxml.jackson.core.jackson-core;version='[2.9.6,2.9.7)',\
+	com.fasterxml.jackson.core.jackson-databind;version='[2.9.6,2.9.7)',\
+	com.fasterxml.jackson.jaxrs.jackson-jaxrs-base;version='[2.9.6,2.9.7)',\
+	com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider;version='[2.9.6,2.9.7)',\
+	com.fasterxml.jackson.module.jackson-module-jaxb-annotations;version='[2.9.6,2.9.7)',\
+	endpoint;version='[0.0.1,0.0.2)',\
+	http;version='[0.0.1,0.0.2)',\
+	http-config;version='[0.0.1,0.0.2)',\
+	jakarta.activation-api;version='[1.2.2,1.2.3)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	jakarta.xml.soap-api;version='[1.4.2,1.4.3)',\
+	jakarta.xml.ws-api;version='[2.3.3,2.3.4)',\
+	org.apache.aries.jax.rs.jackson;version='[1.0.3,1.0.4)',\
+	org.apache.aries.jax.rs.whiteboard;version='[1.0.9,1.0.10)',\
+	org.apache.aries.spifly.dynamic.bundle;version='[1.2.3,1.2.4)',\
+	org.apache.felix.configadmin;version='[1.9.16,1.9.17)',\
+	org.apache.felix.configadmin.plugin.interpolation;version='[1.1.0,1.1.1)',\
+	org.apache.felix.configurator;version='[1.0.10,1.0.11)',\
+	org.apache.felix.converter;version='[1.0.14,1.0.15)',\
+	org.apache.felix.gogo.command;version='[1.1.0,1.1.1)',\
+	org.apache.felix.gogo.jline;version='[1.1.2,1.1.3)',\
+	org.apache.felix.gogo.runtime;version='[1.1.2,1.1.3)',\
+	org.apache.felix.http.jetty;version='[4.0.18,4.0.19)',\
+	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
+	org.apache.felix.scr;version='[2.1.20,2.1.21)',\
+	org.apache.geronimo.specs.geronimo-annotation_1.3_spec;version='[1.1.0,1.1.1)',\
+	org.apache.geronimo.specs.geronimo-jaxrs_2.1_spec;version='[1.1.0,1.1.1)',\
+	org.glassfish.jakarta.json;version='[1.1.5,1.1.6)',\
+	org.jline;version='[3.7.0,3.7.1)',\
+	org.osgi.service.jaxrs;version='[1.0.0,1.0.1)',\
+	org.osgi.util.function;version='[1.1.0,1.1.1)',\
+	osgi.promise;version='[7.0.1,7.0.2)',\
+	slf4j.api;version='[1.7.30,1.7.31)'

--- a/osgi/runtime/app-felix.bndrun
+++ b/osgi/runtime/app-felix.bndrun
@@ -15,5 +15,51 @@ feature.gogo: \
     bnd.identity;id='org.apache.felix.gogo.command',\
     bnd.identity;id='org.apache.felix.gogo.jline',
 
+feature.config-admin: \
+    bnd.identity;id='org.apache.felix.configadmin.plugin.interpolation',\
+    bnd.identity;id='org.glassfish.jakarta.json'
+
 -runrequires: \
-    ${feature.gogo}
+    ${feature.config-admin},\
+    bnd.identity;id='http-config',\
+    ${feature.gogo}, \
+    bnd.identity;id='http', \
+    bnd.identity;id='endpoint', \
+    bnd.identity;id='org.apache.aries.jax.rs.jackson'
+-runbundles: \
+	ch.qos.logback.classic;version='[1.2.0,1.2.1)',\
+	ch.qos.logback.core;version='[1.2.0,1.2.1)',\
+	com.fasterxml.jackson.core.jackson-annotations;version='[2.9.0,2.9.1)',\
+	com.fasterxml.jackson.core.jackson-core;version='[2.9.6,2.9.7)',\
+	com.fasterxml.jackson.core.jackson-databind;version='[2.9.6,2.9.7)',\
+	com.fasterxml.jackson.jaxrs.jackson-jaxrs-base;version='[2.9.6,2.9.7)',\
+	com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider;version='[2.9.6,2.9.7)',\
+	com.fasterxml.jackson.module.jackson-module-jaxb-annotations;version='[2.9.6,2.9.7)',\
+	endpoint;version='[0.0.1,0.0.2)',\
+	http;version='[0.0.1,0.0.2)',\
+	http-config;version='[0.0.1,0.0.2)',\
+	jakarta.activation-api;version='[1.2.2,1.2.3)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	jakarta.xml.soap-api;version='[1.4.2,1.4.3)',\
+	jakarta.xml.ws-api;version='[2.3.3,2.3.4)',\
+	org.apache.aries.jax.rs.jackson;version='[1.0.3,1.0.4)',\
+	org.apache.aries.jax.rs.whiteboard;version='[1.0.9,1.0.10)',\
+	org.apache.aries.spifly.dynamic.bundle;version='[1.2.3,1.2.4)',\
+	org.apache.felix.configadmin;version='[1.9.16,1.9.17)',\
+	org.apache.felix.configadmin.plugin.interpolation;version='[1.1.0,1.1.1)',\
+	org.apache.felix.configurator;version='[1.0.10,1.0.11)',\
+	org.apache.felix.converter;version='[1.0.14,1.0.15)',\
+	org.apache.felix.gogo.command;version='[1.1.0,1.1.1)',\
+	org.apache.felix.gogo.jline;version='[1.1.2,1.1.3)',\
+	org.apache.felix.gogo.runtime;version='[1.1.2,1.1.3)',\
+	org.apache.felix.http.jetty;version='[4.0.18,4.0.19)',\
+	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
+	org.apache.felix.scr;version='[2.1.20,2.1.21)',\
+	org.apache.geronimo.specs.geronimo-annotation_1.3_spec;version='[1.1.0,1.1.1)',\
+	org.apache.geronimo.specs.geronimo-jaxrs_2.1_spec;version='[1.1.0,1.1.1)',\
+	org.glassfish.jakarta.json;version='[1.1.5,1.1.6)',\
+	org.jline;version='[3.7.0,3.7.1)',\
+	org.osgi.service.jaxrs;version='[1.0.0,1.0.1)',\
+	org.osgi.util.function;version='[1.1.0,1.1.1)',\
+	osgi.promise;version='[7.0.1,7.0.2)',\
+	slf4j.api;version='[1.7.22,1.7.23)'

--- a/osgi/runtime/pom.xml
+++ b/osgi/runtime/pom.xml
@@ -22,12 +22,19 @@
     <properties>
         <osgi.promise.version>7.0.1</osgi.promise.version>
         <org.osgi.service.log.version>1.4.0</org.osgi.service.log.version>
+        <org.apache.felix.configadmin.version>1.9.16</org.apache.felix.configadmin.version>
         <org.apache.felix.scr.version>2.1.20</org.apache.felix.scr.version>
         <bndrun.file>placeholder.bndrun</bndrun.file>
     </properties>
 
     <dependencies>
         <!-- Artifacts :: OSGi Features -->
+        <!-- Artifacts :: OSGi Feature :: Config Admin -->
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.configadmin</artifactId>
+            <version>${org.apache.felix.configadmin.version}</version>
+        </dependency>
         <!-- Artifacts :: OSGi Feature :: Command Line -->
         <dependency>
             <groupId>org.apache.felix</groupId>
@@ -69,11 +76,57 @@
             <version>${org.osgi.service.log.version}</version>
         </dependency>
 
+        <!-- Apache Karaf feature - Config Extension - OSGi R7 Configurator, Config Admin Interpolation  -->
+        <dependency>
+            <groupId>org.millipede</groupId>
+            <artifactId>osgi-config-extension-feature</artifactId>
+            <version>1.0.0</version>
+            <type>xml</type>
+            <classifier>features</classifier>
+        </dependency>
+
         <!-- Artifacts :: Application Specific -->
         <!-- Artifacts :: Project Configuration -->
-        <!-- Artifacts :: Project dependencies -->
-        <!-- Artifacts :: Project -->
+        <dependency>
+            <groupId>org.millipede</groupId>
+            <artifactId>http-config</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
+        <!-- Artifacts :: Project dependencies -->
+        <dependency>
+            <groupId>org.apache.aries.jax.rs</groupId>
+            <artifactId>org.apache.aries.jax.rs.features.whiteboard</artifactId>
+            <version>${org.apache.aries.jax.rs.whiteboard.version}</version>
+            <type>xml</type>
+            <classifier>features</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.jax.rs</groupId>
+            <artifactId>org.apache.aries.jax.rs.features.jackson</artifactId>
+            <version>${org.apache.aries.jax.rs.jackson.version}</version>
+            <type>xml</type>
+            <classifier>features</classifier>
+        </dependency>
+        <!-- Artifacts :: Project -->
+        <dependency>
+            <groupId>org.millipede</groupId>
+            <artifactId>millipede-social-aggregator-osgi-karaf-feature</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+            <type>xml</type>
+            <classifier>features</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.osgi</groupId>
+                    <artifactId>osgi.cmpn</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.spifly</groupId>
+            <artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
+            <version>1.2.3</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -190,6 +243,4 @@
             </dependencies>
         </profile>
     </profiles>
-
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,14 @@
         <bnd.version>5.1.0</bnd.version>
         <maven-jar-plugin.version>3.0.1</maven-jar-plugin.version>
 
+        <org.apache.aries.jax.rs.whiteboard.version>1.0.9-SNAPSHOT</org.apache.aries.jax.rs.whiteboard.version>
+        <org.apache.aries.jax.rs.jackson.version>1.0.3-SNAPSHOT</org.apache.aries.jax.rs.jackson.version>
+
+        <!-- OSGi dependency version -->
+        <osgi.core.version>7.0.0</osgi.core.version>
+        <osgi.cmpn.version>7.0.0</osgi.cmpn.version>
+        <osgi.promise.version>7.0.1</osgi.promise.version>
+        <osgi.annotation.version>7.0.0</osgi.annotation.version>
     </properties>
 
     <distributionManagement>
@@ -45,8 +53,49 @@
         </snapshotRepository>
     </distributionManagement>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>osgi.core</artifactId>
+                <version>${osgi.core.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>osgi.cmpn</artifactId>
+                <version>${osgi.cmpn.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>osgi.annotation</artifactId>
+                <version>${osgi.annotation.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>osgi.promise</artifactId>
+                <version>${osgi.promise.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.aries.jax.rs</groupId>
+                <artifactId>org.apache.aries.jax.rs.whiteboard</artifactId>
+                <version>${org.apache.aries.jax.rs.whiteboard.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.aries.jax.rs</groupId>
+                <artifactId>org.apache.aries.jax.rs.jackson</artifactId>
+                <version>${org.apache.aries.jax.rs.jackson.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <modules>
         <module>osgi</module>
+        <module>http</module>
+        <module>endpoint</module>
+        <module>config</module>
     </modules>
 
     <build>

--- a/settings.xml
+++ b/settings.xml
@@ -41,6 +41,17 @@
                 </snapshots.repo.url>
             </properties>
             <repositories>
+                <!-- Apache Karaf feature - Config Extension - OSGi R7 Configurator, Config Admin Interpolation -->
+                <repository>
+                    <id>gitlab-neo4j-ogm</id>
+                    <url>https://gitlab.com/api/v4/projects/19494109/packages/maven</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
                 <!--
                 Fragment bundle refresh - optional runtime dependency, hosted at Gitlab maven registry.
 


### PR DESCRIPTION
Use Aries JAX-RS Whiteboard as a reference implementation of the OSGi JAX-RS Services Whiteboard 1.0.
Use Aries JAX-RS Jackson integration.

Add demo application and endpoint.
Use OSGi R7 Configurator to configure Http port.
The demonstrator run behavior is identical in pure OSGi environments like Apache Felix or Equinox and Apache Karaf. In the latter, the OSGi R7 configuration overrules the Apache Karaf default Http port setting. Note: For duplicated configuration declarations like Http port is the factory separator (tilde ~) in the PID constellation is most important.