### PR TITLE
Add dynamic port selection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,10 @@ services:
     networks:
       - social-aggregator-network
     command: ["karaf", "run"]
+    environment:
+      - SOCIAL_AGGREGATOR_SERVER_HTTP_PORT=${SOCIAL_AGGREGATOR_SERVER_HTTP_PORT:-8090}
+    ports:
+      - '8000:${SOCIAL_AGGREGATOR_SERVER_HTTP_PORT:-8090}'
 
 networks:
   social-aggregator-network:


### PR DESCRIPTION
Host environment variable SOCIAL_AGGREGATOR_SERVER_HTTP_PORT get used to define the Http port. The variable gets replicated onto the container OS. The OSGi Configurator reads the variable from the OS (with or without docker involved) and initiates the Http server on that port. For the container port mapping, the same strategy applies, see e.g., docker-compose file.